### PR TITLE
🔒 Pin Docker image in GitHub Actions to prevent supply chain attacks

### DIFF
--- a/.github/workflows/minify-js.yml
+++ b/.github/workflows/minify-js.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Minify JS files
-        uses: docker://devatherock/minify-js:3.1.0
+        uses: docker://devatherock/minify-js@sha256:cca5837fabfe5d11d8e751080f9a0de838ebfc58e6fc382c421a22d751b075c0
         with:
           directory: 'src'
           add_suffix: true


### PR DESCRIPTION
🎯 **What:** The `devatherock/minify-js` Docker image in `.github/workflows/minify-js.yml` was using a mutable tag (`3.1.0`), which has been replaced with its corresponding immutable SHA-256 digest.
⚠️ **Risk:** Using mutable tags for Docker images in CI/CD pipelines is a security risk. If the tag is maliciously updated to point to a compromised image, the CI workflow would automatically pull and execute it, potentially leading to a supply chain attack.
🛡️ **Solution:** The fix replaces the `:3.1.0` tag with `@sha256:cca5837fabfe5d11d8e751080f9a0de838ebfc58e6fc382c421a22d751b075c0`, ensuring that the workflow consistently and securely pulls the exact version of the image intended, mitigating the risk of supply chain vulnerabilities.

---
*PR created automatically by Jules for task [18314711274942484256](https://jules.google.com/task/18314711274942484256) started by @jsem-nerad*