### PR TITLE
🧪 [testing improvement] Add unit tests for updateOptions

### DIFF
--- a/tests/mock-browser.js
+++ b/tests/mock-browser.js
@@ -1,0 +1,70 @@
+// Basic browser mock for testing
+global.requestAnimationFrame = (cb) => { /* do not run loop */ return 1; };
+global.cancelAnimationFrame = (id) => {};
+
+global.window = {
+    devicePixelRatio: 1,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    requestAnimationFrame: global.requestAnimationFrame,
+    cancelAnimationFrame: global.cancelAnimationFrame,
+    performance: { now: () => Date.now() },
+    getComputedStyle: () => ({ position: 'static' })
+};
+
+class MockElement {
+    constructor(tagName) {
+        this.tagName = tagName;
+        this.style = {};
+        this.children = [];
+        this.parentNode = null;
+    }
+    appendChild(child) {
+        this.children.push(child);
+        child.parentNode = this;
+    }
+    removeChild(child) {
+        this.children = this.children.filter(c => c !== child);
+        child.parentNode = null;
+    }
+    getBoundingClientRect() {
+        return { width: 800, height: 600, top: 0, left: 0 };
+    }
+    getContext() {
+        return {
+            scale: () => {},
+            clearRect: () => {},
+            beginPath: () => {},
+            arc: () => {},
+            fill: () => {},
+            save: () => {},
+            translate: () => {},
+            rotate: () => {},
+            ellipse: () => {},
+            restore: () => {},
+            fillRect: () => {}
+        };
+    }
+    addEventListener() {}
+    removeEventListener() {}
+}
+
+global.document = {
+    createElement: (tagName) => new MockElement(tagName),
+    querySelector: (selector) => {
+        if (selector === 'body') return new MockElement('body');
+        return new MockElement('div');
+    },
+    body: new MockElement('body')
+};
+
+// Mock performance.now
+global.performance = { now: () => Date.now() };
+
+// Mock HTMLCanvasElement
+global.HTMLCanvasElement = MockElement;
+
+// Require the actual source file
+require('../src/dotwave.js');
+
+module.exports = { window: global.window, document: global.document };

--- a/tests/updateOptions.test.js
+++ b/tests/updateOptions.test.js
@@ -1,0 +1,68 @@
+require('./mock-browser.js');
+
+const assert = require('assert');
+// In node environment, the IIFE attaches DotWave to 'global' if window is not defined.
+// Wait, our mock defines global.window, so it attaches to window.
+const DotWave = global.window.DotWave;
+
+function runTests() {
+    console.log('Running tests for DotWave.prototype.updateOptions...');
+    let passed = 0;
+    let failed = 0;
+
+    function test(name, fn) {
+        try {
+            fn();
+            console.log(`✅ ${name}`);
+            passed++;
+        } catch (error) {
+            console.error(`❌ ${name}`);
+            console.error(error);
+            failed++;
+        }
+    }
+
+    // Basic instance creation
+    const dotwave = new DotWave();
+
+    test('updateOptions should merge simple options', () => {
+        dotwave.updateOptions({ dotColor: 'red', numDots: 100 });
+        assert.strictEqual(dotwave.options.dotColor, 'red');
+        assert.strictEqual(dotwave.options.numDots, 100);
+        // Original default shouldn't change if not specified
+        assert.strictEqual(dotwave.options.backgroundColor, 'black');
+    });
+
+    test('updateOptions should recreate dots when numDots changes', () => {
+        let called = false;
+        dotwave._createDots = () => { called = true; };
+        dotwave.updateOptions({ numDots: 200 });
+        assert.strictEqual(called, true);
+    });
+
+    test('updateOptions should recreate dots when dotStretch changes', () => {
+        let called = false;
+        dotwave._createDots = () => { called = true; };
+        dotwave.updateOptions({ dotStretch: false });
+        assert.strictEqual(called, true);
+    });
+
+    test('updateOptions should recreate dots when rotSmoothing changes', () => {
+        let called = false;
+        dotwave._createDots = () => { called = true; };
+        dotwave.updateOptions({ rotSmoothing: true });
+        assert.strictEqual(called, true);
+    });
+
+    test('updateOptions should not recreate dots for other property changes', () => {
+        let called = false;
+        dotwave._createDots = () => { called = true; };
+        dotwave.updateOptions({ dotColor: 'blue', friction: 0.8 });
+        assert.strictEqual(called, false);
+    });
+
+    console.log(`\nResults: ${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exit(1);
+}
+
+runTests();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `updateOptions` method in `src/dotwave.js` was previously untested. This PR adds unit tests to verify its core logic, ensuring that basic object merging works as expected and that `this._createDots()` is conditionally invoked when specific configuration options change (`numDots`, `dotStretch`, `rotSmoothing`).

📊 **Coverage:** What scenarios are now tested
- Validates basic merging behavior of options object passed to `updateOptions`.
- Verifies that dots are recreated when `numDots` changes.
- Verifies that dots are recreated when `dotStretch` changes.
- Verifies that dots are recreated when `rotSmoothing` changes.
- Ensures that dots are *not* unnecessarily recreated when other independent property changes (e.g., `dotColor`, `friction`).

✨ **Result:** The improvement in test coverage
Introduced a mock browser setup (`tests/mock-browser.js`) and a vanilla Node.js test runner (`tests/updateOptions.test.js`) that safely isolates side-effects to execute standalone JS test files. Test coverage has increased, helping guarantee stability for `DotWave`'s reactive runtime modifications.

---
*PR created automatically by Jules for task [16837735816644289367](https://jules.google.com/task/16837735816644289367) started by @jsem-nerad*