### PR TITLE
Add custom dot shapes/images, motion presets and color palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 
 - Parallax effect for depth perception
 - Fully customizable (colors, sizes, behavior...)
+- Custom dot shapes (squares, triangles, stars, your own images or draw functions)
+- Color palettes - dots pick random colors from a list you define
+- Motion presets - dots can flow in a stream or swirl in a vortex on their own
 - Dot stretching
 - Dot rotation smoothing
 - No dependencies
@@ -161,6 +164,121 @@ To configure DotWave when initializing, use the class options.
 
 You can find the [list of all available attributes here](#option-list).
 
+# Dot shapes & images
+
+By default, DotWave draws circles. Use the `dotShape` option (or the `dot-shape` attribute) to change that:
+
+| Value        | Result                                                            |
+|--------------|-------------------------------------------------------------------|
+| `"circle"`   | The classic dot (default)                                         |
+| `"square"`   | Square dots                                                       |
+| `"triangle"` | Triangle dots that point in the direction of travel when stretched |
+| `"star"`     | Five-pointed stars                                                |
+| `"image"`    | Draws the image from the `dotImage` option instead of a shape     |
+
+```JavaScript
+// Star-shaped dots
+const dotwave = new DotWave({
+  dotShape: 'star',
+  dotMinSize: 2,
+  dotMaxSize: 6,
+});
+
+// Image dots (e.g. snowflakes, logos, sprites...)
+const snow = new DotWave({
+  dotShape: 'image',
+  dotImage: '/images/snowflake.png',
+  dotMinSize: 4,
+  dotMaxSize: 10,
+});
+```
+
+```xml
+<dot-wave dot-shape="triangle"></dot-wave>
+<dot-wave dot-shape="image" dot-image="/images/snowflake.png" dot-min-size="4" dot-max-size="10"></dot-wave>
+```
+
+Some notes on shapes and images:
+
+- All built-in shapes support dot stretching - they rotate towards their direction of travel and stretch along it, just like circles do.
+- Images keep their aspect ratio and are scaled so their larger side matches the dot diameter. Since the default dot sizes (1-3) are quite small, you will usually want to increase `dotMinSize`/`dotMaxSize` for image dots.
+- While the image is loading (or if it fails to load), dots are drawn as regular circles, so the canvas never appears empty.
+- Dot colors do not apply to images - the image keeps its own colors. Per-dot opacity still applies.
+
+### Custom shape functions (JavaScript only)
+
+For full control, `dotShape` also accepts a function that traces a path centered at `(0, 0)`. DotWave handles position, rotation, stretching and filling for you:
+
+```JavaScript
+const dotwave = new DotWave({
+  // A simple diamond shape
+  dotShape: function(ctx, radius) {
+    ctx.moveTo(0, -radius);
+    ctx.lineTo(radius, 0);
+    ctx.lineTo(0, radius);
+    ctx.lineTo(-radius, 0);
+    ctx.closePath();
+  },
+});
+```
+
+# Color palettes
+
+Instead of a single `dotColor`, you can pass an array of colors with `dotColors`. Each dot picks one color from the palette at random when it is created:
+
+```JavaScript
+const dotwave = new DotWave({
+  dotColors: ['#33a6ed', '#ed33a6', 'gold', 'rgb(166, 237, 51)'],
+});
+```
+
+For the HTML element, use a comma-separated list:
+
+```xml
+<dot-wave dot-colors="#33a6ed, #ed33a6, gold"></dot-wave>
+```
+
+When `dotColors` is set (and not empty), it takes precedence over `dotColor`. Updating `dotColor` or `dotColors` via `updateOptions()` re-rolls the colors of all existing dots without resetting their positions. All CSS color formats supported by `dotColor` (named, hex, RGB/RGBA) work in the palette too.
+
+# Motion presets
+
+By default, dots just wander randomly (and react to your cursor). The `motion` option gives them a direction of their own:
+
+| Value      | Result                                                       |
+|------------|--------------------------------------------------------------|
+| `"none"`   | Classic random wandering (default)                           |
+| `"stream"` | Dots constantly flow in one direction, like a river or snowfall |
+| `"vortex"` | Dots swirl around a configurable center point                |
+
+```JavaScript
+// A stream flowing to the bottom-right
+const stream = new DotWave({
+  motion: 'stream',
+  motionAngle: 45,       // Direction in degrees: 0 = right, 90 = down, 180 = left, 270 = up
+  motionStrength: 0.1,   // How strong the flow is
+});
+
+// A vortex swirling around the center
+const vortex = new DotWave({
+  motion: 'vortex',
+  motionStrength: 0.15,
+  motionCenterX: 0.5,    // Center as a fraction of the canvas size (0-1)
+  motionCenterY: 0.5,
+});
+```
+
+```xml
+<dot-wave motion="stream" motion-angle="270" motion-strength="0.08"></dot-wave>
+<dot-wave motion="vortex" motion-strength="0.15"></dot-wave>
+```
+
+Notes on motion presets:
+
+- Motion presets combine with everything else: cursor reactivity, random movement, friction and `maxSpeed` all still apply. For a perfectly uniform stream, set `randomFactor: 0`.
+- `motionStrength` is a continuous force, so its visible speed is balanced against `friction` and capped by `maxSpeed`.
+- For `vortex`, a negative `motionStrength` reverses the spin direction.
+- The vortex center is relative to the canvas size, so `0.5`/`0.5` always stays in the middle, even after resizing. Values outside `0-1` place the center off-canvas, which works too.
+
 # Methods
 
 ```JavaScript
@@ -209,6 +327,14 @@ dotwave.destroy();
 | dot-max-stretch       | dotMaxStretch         | number  | 20       | Maximum stretch amount                                      |
 | rot-smoothing         | rotSmoothing          | boolean | false    | Smoothly rotates dots instead of snapping                   |
 | rotsmoothingintensity | rotSmoothingIntensity | number  | 150      | Rotation smoothing duration (ms)                            |
+| dot-shape             | dotShape              | string  | "circle" | Dot shape: "circle", "square", "triangle", "star", "image"; JS also accepts a custom draw function |
+| dot-image             | dotImage              | string  | null     | Image URL used when dotShape is "image"                     |
+| dot-colors            | dotColors             | array   | null     | Color palette; each dot picks one at random (overrides dotColor). HTML: comma-separated list |
+| motion                | motion                | string  | "none"   | Autonomous motion preset: "none", "stream" or "vortex"      |
+| motion-angle          | motionAngle           | number  | 0        | Stream direction in degrees (0 = right, 90 = down)          |
+| motion-strength       | motionStrength        | number  | 0.05     | Strength of the motion preset force                         |
+| motion-center-x       | motionCenterX         | number  | 0.5      | Vortex center X as a fraction of canvas width (0-1)         |
+| motion-center-y       | motionCenterY         | number  | 0.5      | Vortex center Y as a fraction of canvas height (0-1)        |
 
 ## For HTML
 
@@ -234,7 +360,15 @@ dotwave.destroy();
   dot-stretch-mult="10"
   dot-max-stretch="20"
   rot-smoothing="false"
-  rot-smoothing-intensity="150">
+  rot-smoothing-intensity="150"
+  dot-shape="circle"
+  dot-image=""
+  dot-colors=""
+  motion="none"
+  motion-angle="0"
+  motion-strength="0.05"
+  motion-center-x="0.5"
+  motion-center-y="0.5">
 </dot-wave>
 ```
 
@@ -263,7 +397,15 @@ const dotwave = new DotWave({
   dotStretchMult: 10,          // How much to stretch the dots
   dotMaxStretch: 20,           // Maximum stretch amount
   rotSmoothing: false,         // Toggle for rotation smoothing of dots
-  rotSmoothingIntensity: 150   // Rotation smoothing duration in milliseconds
+  rotSmoothingIntensity: 150,  // Rotation smoothing duration in milliseconds
+  dotShape: 'circle',          // Dot shape: 'circle', 'square', 'triangle', 'star', 'image' or a custom draw function
+  dotImage: null,              // Image URL used when dotShape is 'image'
+  dotColors: null,             // Array of colors; each dot picks one at random (overrides dotColor)
+  motion: 'none',              // Autonomous motion preset: 'none', 'stream' or 'vortex'
+  motionAngle: 0,              // Stream direction in degrees (0 = right, 90 = down)
+  motionStrength: 0.05,        // Strength of the motion preset force
+  motionCenterX: 0.5,          // Vortex center X as a fraction of canvas width (0-1)
+  motionCenterY: 0.5           // Vortex center Y as a fraction of canvas height (0-1)
 });
 ```
 > *Note, that  `rotSmoothing: false` skips the rotation lerping calculations and is therefore more performant than using `rotSmoothingIntensity: 0`, same logic applies to `dotStretch`.*

--- a/examples/dotwave-new-features.html
+++ b/examples/dotwave-new-features.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>DotWave Shapes, Motion & Color Palettes Example</title>
+
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+        }
+
+        .demo {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 350px;
+        }
+
+        .demo h2 {
+            color: white;
+            text-shadow: 0 0 8px black;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Star-shaped dots with a color palette -->
+    <div id="demo-stars" class="demo">
+        <h2>Stars with a color palette</h2>
+    </div>
+
+    <!-- Stream motion: dots flow to the right on their own -->
+    <div id="demo-stream" class="demo">
+        <h2>Stream motion</h2>
+    </div>
+
+    <!-- Vortex motion: dots swirl around the center -->
+    <div id="demo-vortex" class="demo">
+        <h2>Vortex motion</h2>
+    </div>
+
+    <!-- DotWave element with the new attributes -->
+    <dot-wave
+        class="demo"
+        dot-shape="triangle"
+        dot-colors="#33a6ed, #ed33a6, #a6ed33"
+        motion="stream"
+        motion-angle="270"
+        motion-strength="0.08">
+        <h2>&lt;dot-wave&gt; element with triangles streaming upwards</h2>
+    </dot-wave>
+
+    <script src="/src/dotwave.js"></script>
+    <script src="/src/dotwave-element.js"></script>
+    <script>
+        // Star-shaped dots, each picking a random color from the palette
+        new DotWave({
+            container: '#demo-stars',
+            dotShape: 'star',
+            dotColors: ['#ffd700', '#ff6b6b', '#4ecdc4', '#c44dff'],
+            dotMinSize: 2,
+            dotMaxSize: 6,
+            dotStretch: false,
+        });
+
+        // Stream: a constant flow to the right (0 degrees)
+        new DotWave({
+            container: '#demo-stream',
+            motion: 'stream',
+            motionAngle: 0,
+            motionStrength: 0.1,
+            dotColors: ['#33a6ed', '#1c6fa3', '#7fc8f0'],
+        });
+
+        // Vortex: dots swirl around the center of the container
+        new DotWave({
+            container: '#demo-vortex',
+            motion: 'vortex',
+            motionStrength: 0.15,
+            motionCenterX: 0.5,
+            motionCenterY: 0.5,
+            dotColors: ['#ff9f43', '#ee5253', '#feca57'],
+        });
+    </script>
+</body>
+</html>

--- a/src/dotwave-element.js
+++ b/src/dotwave-element.js
@@ -12,11 +12,13 @@ class DotWaveElement extends HTMLElement {
   // Define which attributes to observe for changes
   static get observedAttributes() {
     return [
-      'num-dots', 'dot-color', 'background-color', 'dot-min-size', 'dot-max-size',
+      'num-dots', 'dot-color', 'dot-colors', 'background-color', 'dot-min-size', 'dot-max-size',
       'dot-min-opacity', 'dot-max-opacity', 'influence-radius', 'influence-strength',
       'random-factor', 'friction', 'max-speed', 'reactive', 'z-index',
       'mouse-speed-decay', 'max-mouse-speed', 'dot-stretch', 'dot-stretch-mult',
-      'dot-max-stretch', 'rot-smoothing', 'rot-smoothing-intensity'
+      'dot-max-stretch', 'rot-smoothing', 'rot-smoothing-intensity',
+      'dot-shape', 'dot-image', 'motion', 'motion-angle', 'motion-strength',
+      'motion-center-x', 'motion-center-y'
     ];
   }
 
@@ -33,6 +35,32 @@ class DotWaveElement extends HTMLElement {
     if (oldValue !== newValue && this.isInitialized && this.dotwave) {
       this.updateDotWaveOptions();
     }
+  }
+
+  // Split a comma-separated color list, ignoring commas inside
+  // parentheses so values like rgb(0, 255, 0) stay intact
+  static parseColorList(value) {
+    if (!value) return null;
+
+    const items = [];
+    let depth = 0;
+    let current = '';
+
+    for (const char of value) {
+      if (char === '(') depth++;
+      else if (char === ')') depth--;
+
+      if (char === ',' && depth === 0) {
+        items.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    items.push(current.trim());
+
+    const filtered = items.filter(Boolean);
+    return filtered.length > 0 ? filtered : null;
   }
 
   // Called when element is removed from DOM
@@ -52,9 +80,10 @@ class DotWaveElement extends HTMLElement {
     const attributeMap = {
       'num-dots': { prop: 'numDots', type: 'number', default: 400 },
       'dot-color': { prop: 'dotColor', type: 'string', default: 'white' },
+      'dot-colors': { prop: 'dotColors', type: 'array', default: null },
       'background-color': { prop: 'backgroundColor', type: 'string', default: 'black' },
       'dot-min-size': { prop: 'dotMinSize', type: 'number', default: 1 },
-      'dot-maxs-ize': { prop: 'dotMaxSize', type: 'number', default: 3 },
+      'dot-max-size': { prop: 'dotMaxSize', type: 'number', default: 3 },
       'dot-min-opacity': { prop: 'dotMinOpacity', type: 'number', default: 0.5 },
       'dot-max-opacity': { prop: 'dotMaxOpacity', type: 'number', default: 1 },
       'influence-radius': { prop: 'influenceRadius', type: 'number', default: 100 },
@@ -70,7 +99,14 @@ class DotWaveElement extends HTMLElement {
       'dot-stretch-mult': { prop: 'dotStretchMult', type: 'number', default: 10 },
       'dot-max-stretch': { prop: 'dotMaxStretch', type: 'number', default: 20 },
       'rot-smoothing': { prop: 'rotSmoothing', type: 'boolean', default: false },
-      'rot-smoothing-intensity': { prop: 'rotSmoothingIntensity', type: 'number', default: 150 }
+      'rot-smoothing-intensity': { prop: 'rotSmoothingIntensity', type: 'number', default: 150 },
+      'dot-shape': { prop: 'dotShape', type: 'string', default: 'circle' },
+      'dot-image': { prop: 'dotImage', type: 'string', default: null },
+      'motion': { prop: 'motion', type: 'string', default: 'none' },
+      'motion-angle': { prop: 'motionAngle', type: 'number', default: 0 },
+      'motion-strength': { prop: 'motionStrength', type: 'number', default: 0.05 },
+      'motion-center-x': { prop: 'motionCenterX', type: 'number', default: 0.5 },
+      'motion-center-y': { prop: 'motionCenterY', type: 'number', default: 0.5 }
     };
 
     // Process each attribute
@@ -85,6 +121,9 @@ class DotWaveElement extends HTMLElement {
         } else if (config.type === 'number') {
           const numValue = parseFloat(value);
           options[config.prop] = isNaN(numValue) ? config.default : numValue;
+        } else if (config.type === 'array') {
+          // Comma-separated list, e.g. dot-colors="#ff0000, #00ff00, blue"
+          options[config.prop] = DotWaveElement.parseColorList(value) || config.default;
         } else {
           // String values
           options[config.prop] = value || config.default;
@@ -194,6 +233,56 @@ class DotWaveElement extends HTMLElement {
       this.setAttribute('background-color', value);
     } else {
       this.removeAttribute('background-color');
+    }
+  }
+
+  get dotColors() {
+    return DotWaveElement.parseColorList(this.getAttribute('dot-colors'));
+  }
+
+  set dotColors(value) {
+    if (Array.isArray(value) && value.length > 0) {
+      this.setAttribute('dot-colors', value.join(','));
+    } else if (typeof value === 'string' && value) {
+      this.setAttribute('dot-colors', value);
+    } else {
+      this.removeAttribute('dot-colors');
+    }
+  }
+
+  get dotShape() {
+    return this.getAttribute('dot-shape') || 'circle';
+  }
+
+  set dotShape(value) {
+    if (value) {
+      this.setAttribute('dot-shape', value);
+    } else {
+      this.removeAttribute('dot-shape');
+    }
+  }
+
+  get dotImage() {
+    return this.getAttribute('dot-image');
+  }
+
+  set dotImage(value) {
+    if (value) {
+      this.setAttribute('dot-image', value);
+    } else {
+      this.removeAttribute('dot-image');
+    }
+  }
+
+  get motion() {
+    return this.getAttribute('motion') || 'none';
+  }
+
+  set motion(value) {
+    if (value) {
+      this.setAttribute('motion', value);
+    } else {
+      this.removeAttribute('motion');
     }
   }
 

--- a/src/dotwave.js
+++ b/src/dotwave.js
@@ -1,7 +1,7 @@
 /**
  * DotWave.js - An Interactive Dot Canvas JavaScript Library
  * Creates animated dots that react to cursor movement
- * @version 1.1.0
+ * @version 1.2.0
  */
 (function(global) {
     'use strict';
@@ -34,7 +34,15 @@
             dotStretchMult: 10,          // How much to stretch the dots
             dotMaxStretch: 20,           // Maximum stretch amount
             rotSmoothing: false,         // Toggle for rotation smoothing of dots
-            rotSmoothingIntensity: 150   // Rotation smoothing duration in milliseconds
+            rotSmoothingIntensity: 150,  // Rotation smoothing duration in milliseconds
+            dotShape: 'circle',          // Dot shape: 'circle', 'square', 'triangle', 'star', 'image' or a custom draw function
+            dotImage: null,              // Image URL used when dotShape is 'image'
+            dotColors: null,             // Array of colors; each dot picks one at random (overrides dotColor)
+            motion: 'none',              // Autonomous motion preset: 'none', 'stream' or 'vortex'
+            motionAngle: 0,              // Stream direction in degrees (0 = right, 90 = down)
+            motionStrength: 0.05,        // Strength of the motion preset force
+            motionCenterX: 0.5,          // Vortex center X as a fraction of canvas width (0-1)
+            motionCenterY: 0.5           // Vortex center Y as a fraction of canvas height (0-1)
         };
         
         // Merge options with defaults
@@ -57,7 +65,10 @@
         this.resizeTimeout = null;
         this.lastFrameTime = 0;
         this.isMouseOver = false;
-        
+        this.dotImageEl = null;
+        this.dotImageReady = false;
+        this._dotImageSrc = null;
+
         // Initialize the canvas
         this.init();
     }
@@ -92,7 +103,10 @@
         
         // Set initial canvas size
         this._updateCanvasSize();
-        
+
+        // Start loading the dot image if one is configured
+        this._loadImage();
+
         // Create dots
         this._createDots();
         
@@ -200,6 +214,55 @@
     };
     
     /**
+     * Pick a color for a single dot
+     * Uses a random entry from the dotColors palette when provided,
+     * otherwise falls back to dotColor
+     * @return {String} CSS color
+     */
+    DotWave.prototype._pickDotColor = function() {
+        const colors = this.options.dotColors;
+        if (Array.isArray(colors) && colors.length > 0) {
+            return colors[Math.floor(Math.random() * colors.length)];
+        }
+        return this.options.dotColor;
+    };
+
+    /**
+     * Load the dot image when dotShape is 'image'
+     * Dots are drawn as regular circles until the image finishes loading
+     */
+    DotWave.prototype._loadImage = function() {
+        const src = this.options.dotShape === 'image' ? this.options.dotImage : null;
+
+        if (!src) {
+            this._dotImageSrc = null;
+            this.dotImageEl = null;
+            this.dotImageReady = false;
+            return;
+        }
+
+        // Skip reload if the same image is already loading or loaded
+        if (this._dotImageSrc === src) return;
+
+        this._dotImageSrc = src;
+        this.dotImageReady = false;
+
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => {
+            // Ignore stale loads if the image was changed in the meantime
+            if (this._dotImageSrc === src) {
+                this.dotImageEl = img;
+                this.dotImageReady = true;
+            }
+        };
+        img.onerror = () => {
+            console.error('DotWave: Failed to load dot image: ' + src);
+        };
+        img.src = src;
+    };
+
+    /**
      * Create dots with random properties
      */
     DotWave.prototype._createDots = function() {
@@ -215,6 +278,7 @@
                 z: z, // Depth value
                 radius: this.options.dotMinSize + z * (this.options.dotMaxSize - this.options.dotMinSize),
                 alpha: this.options.dotMinOpacity + z * (this.options.dotMaxOpacity - this.options.dotMinOpacity),
+                color: this._pickDotColor(),
                 vx: (Math.random() - 0.5) * 1.5,
                 vy: (Math.random() - 0.5) * 1.5,
                 // Deeper dots move slower to create parallax effect
@@ -337,77 +401,165 @@
      * @param {Number} deltaTime - Time elapsed since last frame
      */
     DotWave.prototype._drawDot = function(dot, deltaTime) {
-        const fillStyle = this._getRGBA(this.options.dotColor, dot.alpha);
-        
-        // Early exit for regular dots when stretching is disabled
-        if (!this.options.dotStretch) {
+        const shape = this.options.dotShape;
+
+        // Calculate stretch amount and rotation when stretching is enabled
+        let stretchAmount = 0;
+        if (this.options.dotStretch) {
+            const vxSq = dot.vx * dot.vx;
+            const vySq = dot.vy * dot.vy;
+            const speed = Math.sqrt(vxSq + vySq);
+
+            // Calculate stretch amount proportional to speed
+            const normalizedSpeed = Math.min(speed / this.options.maxSpeed, 1);
+            stretchAmount = normalizedSpeed * this.options.dotStretchMult;
+
+            // Apply maximum stretch limit if defined
+            if (this.options.dotMaxStretch) {
+                stretchAmount = Math.min(stretchAmount, this.options.dotMaxStretch);
+            }
+
+            if (stretchAmount < 0.01) {
+                // No significant stretch, skip rotation handling
+                stretchAmount = 0;
+            } else {
+                // Calculate target angle based on velocity
+                const targetAngle = Math.atan2(dot.vy, dot.vx);
+
+                // Handle rotation based on rotSmoothing setting
+                if (this.options.rotSmoothing) {
+                    // Smooth rotation: interpolate towards target
+                    dot.targetAngle = targetAngle;
+
+                    // Calculate rotation lerp factor based on deltaTime and rotSmoothingIntensity
+                    const rotationFactor = this.options.rotSmoothingIntensity <= 0 ?
+                        1 : Math.min(deltaTime / this.options.rotSmoothingIntensity, 1);
+
+                    // Smoothly interpolate current angle towards target
+                    dot.currentAngle = this._lerpAngle(dot.currentAngle, dot.targetAngle, rotationFactor);
+                } else {
+                    // Instant rotation: directly set angle
+                    dot.currentAngle = targetAngle;
+                }
+            }
+        }
+
+        // Image dots are drawn separately
+        if (shape === 'image') {
+            this._drawImageDot(dot, stretchAmount);
+            return;
+        }
+
+        const fillStyle = this._getRGBA(dot.color, dot.alpha);
+
+        // Fast path: default circle without stretch
+        if (stretchAmount === 0 && shape === 'circle') {
             this.ctx.beginPath();
             this.ctx.arc(dot.x, dot.y, dot.radius, 0, Math.PI * 2);
             this.ctx.fillStyle = fillStyle;
             this.ctx.fill();
             return;
         }
-        
-        // Only calculate stretching-related values when stretching is enabled
-        const vxSq = dot.vx * dot.vx;
-        const vySq = dot.vy * dot.vy;
-        const speed = Math.sqrt(vxSq + vySq);
-        
-        // Calculate stretch amount proportional to speed
-        const normalizedSpeed = Math.min(speed / this.options.maxSpeed, 1);
-        let stretchAmount = normalizedSpeed * this.options.dotStretchMult;
-        
-        // Apply maximum stretch limit if defined
-        if (this.options.dotMaxStretch) {
-            stretchAmount = Math.min(stretchAmount, this.options.dotMaxStretch);
-        }
-        
-        // If there's no significant stretch, draw regular circle
-        if (stretchAmount < 0.01) {
-            this.ctx.beginPath();
-            this.ctx.arc(dot.x, dot.y, dot.radius, 0, Math.PI * 2);
-            this.ctx.fillStyle = fillStyle;
-            this.ctx.fill();
-            return;
-        }
-        
-        // Calculate target angle based on velocity
-        const targetAngle = Math.atan2(dot.vy, dot.vx);
-        
-        // Handle rotation based on rotSmoothing setting
-        if (this.options.rotSmoothing) {
-            // Smooth rotation: interpolate towards target
-            dot.targetAngle = targetAngle;
-            
-            // Calculate rotation lerp factor based on deltaTime and rotSmoothingIntensity
-            const rotationFactor = this.options.rotSmoothingIntensity <= 0 ? 
-                1 : Math.min(deltaTime / this.options.rotSmoothingIntensity, 1);
-            
-            // Smoothly interpolate current angle towards target
-            dot.currentAngle = this._lerpAngle(dot.currentAngle, dot.targetAngle, rotationFactor);
-        } else {
-            // Instant rotation: directly set angle
-            dot.currentAngle = targetAngle;
-        }
-        
-        // Calculate ellipse dimensions
-        const radiusX = dot.radius + stretchAmount;
-        const radiusY = dot.radius;
-        
-        // Save context state
+
+        // Transformed path: rotate towards velocity and stretch along the movement axis
         this.ctx.save();
-        
-        // Translate to dot position and rotate
         this.ctx.translate(dot.x, dot.y);
-        this.ctx.rotate(dot.currentAngle);
-        
-        // Draw stretched ellipse
+        if (stretchAmount > 0) {
+            this.ctx.rotate(dot.currentAngle);
+            this.ctx.scale((dot.radius + stretchAmount) / dot.radius, 1);
+        }
+
         this.ctx.beginPath();
-        this.ctx.ellipse(0, 0, radiusX, radiusY, 0, 0, Math.PI * 2);
+        this._traceShape(shape, dot.radius);
         this.ctx.fillStyle = fillStyle;
         this.ctx.fill();
-        
-        // Restore context state
+
+        this.ctx.restore();
+    };
+
+    /**
+     * Trace the path of a dot shape centered at the origin
+     * @param {String|Function} shape - Shape name or custom draw function
+     * @param {Number} r - Dot radius
+     */
+    DotWave.prototype._traceShape = function(shape, r) {
+        const ctx = this.ctx;
+
+        // Custom shapes: a function that traces a path centered at (0, 0)
+        if (typeof shape === 'function') {
+            shape(ctx, r);
+            return;
+        }
+
+        switch (shape) {
+            case 'square':
+                ctx.rect(-r, -r, r * 2, r * 2);
+                break;
+            case 'triangle':
+                // Equilateral triangle pointing in the direction of travel
+                ctx.moveTo(r, 0);
+                ctx.lineTo(-r * 0.5, r * 0.866);
+                ctx.lineTo(-r * 0.5, -r * 0.866);
+                ctx.closePath();
+                break;
+            case 'star': {
+                // Five-pointed star
+                const innerR = r * 0.45;
+                let rot = -Math.PI / 2;
+                const step = Math.PI / 5;
+                ctx.moveTo(Math.cos(rot) * r, Math.sin(rot) * r);
+                for (let i = 0; i < 5; i++) {
+                    rot += step;
+                    ctx.lineTo(Math.cos(rot) * innerR, Math.sin(rot) * innerR);
+                    rot += step;
+                    ctx.lineTo(Math.cos(rot) * r, Math.sin(rot) * r);
+                }
+                ctx.closePath();
+                break;
+            }
+            default:
+                ctx.arc(0, 0, r, 0, Math.PI * 2);
+        }
+    };
+
+    /**
+     * Draw a dot using the configured image
+     * Falls back to a circle while the image is loading
+     * @param {Object} dot - The dot object
+     * @param {Number} stretchAmount - Stretch amount along the movement axis
+     */
+    DotWave.prototype._drawImageDot = function(dot, stretchAmount) {
+        if (!this.dotImageReady) {
+            this.ctx.beginPath();
+            this.ctx.arc(dot.x, dot.y, dot.radius, 0, Math.PI * 2);
+            this.ctx.fillStyle = this._getRGBA(dot.color, dot.alpha);
+            this.ctx.fill();
+            return;
+        }
+
+        const img = this.dotImageEl;
+
+        // Scale the image so its larger side matches the dot diameter,
+        // preserving the image aspect ratio
+        const size = dot.radius * 2;
+        const ratio = img.naturalWidth / img.naturalHeight;
+        let w, h;
+        if (ratio >= 1) {
+            w = size;
+            h = size / ratio;
+        } else {
+            h = size;
+            w = size * ratio;
+        }
+
+        this.ctx.save();
+        this.ctx.globalAlpha = dot.alpha;
+        this.ctx.translate(dot.x, dot.y);
+        if (stretchAmount > 0) {
+            this.ctx.rotate(dot.currentAngle);
+            this.ctx.scale((dot.radius + stretchAmount) / dot.radius, 1);
+        }
+        this.ctx.drawImage(img, -w / 2, -h / 2, w, h);
         this.ctx.restore();
     };
     
@@ -451,6 +603,19 @@
             influenceRadiusSq = influenceRadius * influenceRadius; // Avoid sqrt in distance check
             normalizedInfluenceStrength = this.options.influenceStrength;
         }
+
+        // Pre-calculate motion preset values
+        const motion = this.options.motion;
+        const motionStrength = this.options.motionStrength;
+        let streamVX, streamVY, vortexX, vortexY;
+        if (motion === 'stream') {
+            const motionAngleRad = this.options.motionAngle * Math.PI / 180;
+            streamVX = Math.cos(motionAngleRad) * motionStrength;
+            streamVY = Math.sin(motionAngleRad) * motionStrength;
+        } else if (motion === 'vortex') {
+            vortexX = this.options.motionCenterX * this.width;
+            vortexY = this.options.motionCenterY * this.height;
+        }
         
         // Update and draw dots
         for (let i = 0; i < this.dots.length; i++) {
@@ -475,6 +640,25 @@
                 }
             }
             
+            // Apply autonomous motion preset (frame-rate independent)
+            if (motion === 'stream') {
+                // Constant directional flow
+                dot.vx += streamVX * deltaTime;
+                dot.vy += streamVY * deltaTime;
+            } else if (motion === 'vortex') {
+                const cdx = dot.x - vortexX;
+                const cdy = dot.y - vortexY;
+                const cDist = Math.sqrt(cdx * cdx + cdy * cdy) || 1;
+                const nx = cdx / cDist;
+                const ny = cdy / cDist;
+
+                // Tangential force spins dots around the center, with a slight
+                // inward pull (fading near the center) to hold the swirl together
+                const inward = 0.2 * Math.min(cDist / 100, 1);
+                dot.vx += (-ny - nx * inward) * motionStrength * deltaTime;
+                dot.vy += (nx - ny * inward) * motionStrength * deltaTime;
+            }
+
             // Add some randomness to movement (frame-rate independent)
             dot.vx += (Math.random() - 0.5) * randomFactor * deltaTime;
             dot.vy += (Math.random() - 0.5) * randomFactor * deltaTime;
@@ -595,13 +779,24 @@
      * @param {Object} options - New options
      */
     DotWave.prototype.updateOptions = function(options) {
-        this.options = this._mergeOptions(this.options, options || {});
-        
+        options = options || {};
+        this.options = this._mergeOptions(this.options, options);
+
         // Recreate dots if number changed, stretching was toggled, or rotation settings changed
-        if (options.numDots !== undefined || 
-            options.dotStretch !== undefined || 
+        if (options.numDots !== undefined ||
+            options.dotStretch !== undefined ||
             options.rotSmoothing !== undefined) {
             this._createDots();
+        } else if (options.dotColor !== undefined || options.dotColors !== undefined) {
+            // Reassign dot colors without resetting positions
+            for (let i = 0; i < this.dots.length; i++) {
+                this.dots[i].color = this._pickDotColor();
+            }
+        }
+
+        // Reload the dot image if the shape or image changed
+        if (options.dotShape !== undefined || options.dotImage !== undefined) {
+            this._loadImage();
         }
     };
     


### PR DESCRIPTION
- dotShape option: 'circle', 'square', 'triangle', 'star', 'image' (with dotImage URL) or a custom path-drawing function; all shapes support stretching and rotation towards the direction of travel
- motion presets: 'stream' (directional flow with motionAngle) and 'vortex' (swirl around motionCenterX/Y), both frame-rate independent and combinable with cursor reactivity
- dotColors palette: each dot picks a random color from the array, overriding dotColor; updateOptions re-rolls colors in place
- expose all new options as <dot-wave> attributes, with a parenthesis-aware parser so rgb()/rgba() values work in dot-colors
- fix 'dot-maxs-ize' typo that made the dot-max-size attribute ignored
- document everything in the README and add a showcase example page

https://claude.ai/code/session_01X4mR31jHxeKaZoiT3s8gwR